### PR TITLE
feat(report): add simple reporter to console

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,8 @@
     "glob": "^10.4.1",
     "junit2json": "^3.1.10",
     "langchain": "0.2.5",
+    "marked": "^12.0.2",
+    "marked-terminal": "^7.0.0",
     "picocolors": "^1.0.1",
     "yargs": "^17.7.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,12 @@ importers:
       langchain:
         specifier: 0.2.5
         version: 0.2.5(handlebars@4.7.8)(ignore@5.3.1)(openai@4.49.1)
+      marked:
+        specifier: ^12.0.2
+        version: 12.0.2
+      marked-terminal:
+        specifier: ^7.0.0
+        version: 7.0.0(marked@12.0.2)
       picocolors:
         specifier: ^1.0.1
         version: 1.0.1

--- a/src/Agent/prompts.ts
+++ b/src/Agent/prompts.ts
@@ -27,6 +27,7 @@ const testAgentPrompt: AgentPrompt = [
   ---<path to test>---
   <test code analysis>
   ---end---
+  Use Github Markdown format for the output with 3 backticks for code snippets and headings as needed
   `,
   ],
 ]
@@ -45,12 +46,15 @@ export const enumeratorAgentPrompt: AgentPrompt = [
     {tests}
 
    Return the list short (up to 200 symbols) and clear suggestions for code blocks to improve them, skip the recommendation if it is not Enumerator anti-pattern.
+
   ---recommendation---
   Suggestion:
   <suggestion to improve>
   Code:
   <block of code with anti-pattern>
   ---end---
+
+  Use Github Markdown format for the output with 3 backticks for code snippets and headings as needed
    `,
   ],
 ]
@@ -74,6 +78,7 @@ const coverageAgentPrompt: AgentPrompt = [
   ---<path to test>---
   <test code>
   ---end---
+  Use Github Markdown format for the output with 3 backticks for code snippets and headings as needed
    `,
   ],
 ]
@@ -97,6 +102,7 @@ const mutationAgentPrompt: AgentPrompt = [
   ---<path to test>---
   <test code>
   ---end---
+  Use Github Markdown format for the output with 3 backticks for code snippets and headings as needed
   `,
   ],
 ]
@@ -117,6 +123,7 @@ const linterAgentPrompt: AgentPrompt = [
   ---<path to code file>---
   <code>
   ---end---
+  Use Github Markdown format for the output with 3 backticks for code snippets and headings as needed
   `,
   ],
 ]

--- a/src/commands/go.ts
+++ b/src/commands/go.ts
@@ -10,6 +10,7 @@ import { spawnSync } from 'node:child_process'
 import { AIModel, getAIModel } from '../utils/chatModels'
 import { FinalInputData } from '../types/final-input-data'
 import { AgentsManager } from '../agents-manager'
+import { writeResultsReport } from '../utils/reporter'
 
 interface GoArgv {
   repo?: string
@@ -121,7 +122,8 @@ export async function handler(argv: ArgumentsCamelCase<GoArgv>) {
   // agentManager.addAgent(mutationAgent)
 
   const results = await agentManager.run()
-  results.forEach((reSult) => logger.log(reSult))
+
+  writeResultsReport(results)
 
   /**
    *

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,7 @@
+declare module 'marked-terminal' {
+  declare function Renderer(options, highlightOptions)
+  function markedTerminal(text?: string, options?: unknow): string
+  export function markedTerminal(options, highlightOptions): string
+
+  export default Renderer
+}

--- a/src/utils/reporter.ts
+++ b/src/utils/reporter.ts
@@ -1,0 +1,14 @@
+// import { marked } from 'marked'
+// import MarkedTerminal from 'marked-terminal'
+
+import { logger } from '../logger'
+
+// const renderer = MarkedTerminal()
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// marked.setOptions({ renderer })
+
+export const writeResultsReport = (results: string[]) => {
+  // results.forEach((result) => logger.log(marked(result)))
+  results.forEach((result) => logger.log(result))
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/node20/tsconfig.json",
   "compilerOptions": {
+    "allowJs": true,
     "outDir": "dist/src",
     "baseUrl": ".",
     "module": "esnext",


### PR DESCRIPTION
I tried using marked and marked-terminal for markdown formatting to console, but it has problems with official typings.